### PR TITLE
Make more clear that this repository should no longer be used

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+CAUTION: You are probably making a PR in the wrong place.
+
+If you want to add a new library: open a Pull Request at https://github.com/macchina/showcase
+
+If you want to correct an existing library, find its repository at https://macchina.github.io/showcase/libraries.html and open your Pull Request there

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+**This is an obsolete repository that has not yet been deleted.  Please use the [Libraries page on the Macchina Community Showcase](https://macchina.github.io/showcase/libraries.html) to find libraries for the M2.**
+
+___
 ## Macchina M2 Libraries
 
 Here is where we will be keeping all of our M2 code. We encourage you to make suggestions, make pull requests, and generally get involved! Thanks for visiting.


### PR DESCRIPTION
Libraries have their own repositories now and the [Macchina Community Showcase](https://github.com/macchina/showcase) contains the listing of libraries.